### PR TITLE
Cache payload in _properties

### DIFF
--- a/src/ScopedApplications/sys_script_include/Probe.js
+++ b/src/ScopedApplications/sys_script_include/Probe.js
@@ -64,9 +64,10 @@ Probe.prototype = {
     },
      
     getPayload: function(){
-         
-        var payload = this._eccGr.getValue("payload");
-        return payload;
+        if (this._properties["payload"] == undefined || this._properties["payload"] == null) { 
+            this._properties["payload"] = this._eccGr.getValue("payload");
+        }
+        return this._properties["payload"];
     },
      
     setEccQueueRecord: function(val){


### PR DESCRIPTION
This bit us earlier, as we were calling:

``` javascript
var probe = Probe.createProbeResponse(current),
    payload = probe.getPayload();
```

but, though `createProbeResponse` calls `Probe.getPayloadValue`, which abstracts over the attachment vs non-attachment payload possibilities, calling `probe.getPayload()` was pulling the payload directly out of `current` again, which causes problems when you think the "attachment payload" case is already covered.

This change would only pull the `payload` out of the `eccGr` if it hasn't already been stored in `_properties["payload"]`.
